### PR TITLE
fixes knex configuration so cli will run properly

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -3,6 +3,7 @@ const environment = 'development'
 import Knex from 'knex'
 
 const knex = Knex(config[environment])
-knex.migrate.latest([config])
 
 export default knex
+
+knex.migrate.latest([config])

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   development: {
     client: 'postgresql',
     connection: `postgres://${process.env.USER}@localhost:5432/lil_bytes_development`


### PR DESCRIPTION
- the CLI entry point for Knex runs before babel transpilation so `export default` will not be supported
- the easiest way to solve this problem is to change the export syntax to  ES5 `module.exports =` in lieu of this problem being solved 
- this also allows for migrations to be run properly with the `npm start` script

https://github.com/tgriesser/knex/issues/1232

